### PR TITLE
Add demuxer RTSP example

### DIFF
--- a/Arduino_package/hardware/cores/ambpro2/demuxer_drv.c
+++ b/Arduino_package/hardware/cores/ambpro2/demuxer_drv.c
@@ -3,14 +3,13 @@
 #include "module_demuxer.h"
 
 static demuxer_params_t demuxer_params = {
-	.start_time     = 0,
-	.stream_type    = 0,
-	.loop_mode      = 0, //0 no loop, 1 loop
+    .start_time = 0,
+    .stream_type = 0,
+    .loop_mode = 0,    // 0 no loop, 1 loop
 
-	.record_file_name = "",
-	.mem_total_size = 0,
-	.mem_block_size = 0
-};
+    .record_file_name = "",
+    .mem_total_size = 0,
+    .mem_block_size = 0};
 
 mm_context_t *demuxerInit(void)
 {
@@ -22,11 +21,11 @@ mm_context_t *demuxerDeinit(mm_context_t *p)
     return mm_module_close(p);
 }
 
-void demuxerOpen(mm_context_t *p, const char* file_name, uint8_t stream_type, uint32_t loop_mode, uint32_t start_time)
+void demuxerOpen(mm_context_t *p, const char *file_name, uint8_t stream_type, uint32_t loop_mode, uint32_t start_time)
 {
-     demuxer_params.start_time = start_time;
-     demuxer_params.stream_type = stream_type;
-     demuxer_params.loop_mode = loop_mode;
+    demuxer_params.start_time = start_time;
+    demuxer_params.stream_type = stream_type;
+    demuxer_params.loop_mode = loop_mode;
 
     // Copy the file name into the structure
     strncpy(demuxer_params.record_file_name, file_name, sizeof(demuxer_params.record_file_name) - 1);
@@ -61,4 +60,3 @@ void demuxerResume(mm_context_t *p)
     printf("Set RESUME for the MP4\r\n");
     mm_module_ctrl(p, CMD_DEMUXER_STREAM_RESUME, 0);
 }
-

--- a/Arduino_package/hardware/cores/ambpro2/demuxer_drv.c
+++ b/Arduino_package/hardware/cores/ambpro2/demuxer_drv.c
@@ -45,7 +45,6 @@ void demuxerOpen(mm_context_t *p, const char *file_name, uint8_t stream_type, ui
 
 void demuxerStart(mm_context_t *p)
 {
-    printf("CMD_DEMUXER_STREAM_START\r\n");
     mm_module_ctrl(p, CMD_DEMUXER_STREAM_START, 0);
 }
 

--- a/Arduino_package/hardware/cores/ambpro2/demuxer_drv.c
+++ b/Arduino_package/hardware/cores/ambpro2/demuxer_drv.c
@@ -1,0 +1,64 @@
+#include "demuxer_drv.h"
+#include "mmf2_module.h"
+#include "module_demuxer.h"
+
+static demuxer_params_t demuxer_params = {
+	.start_time     = 0,
+	.stream_type    = 0,
+	.loop_mode      = 0, //0 no loop, 1 loop
+
+	.record_file_name = "",
+	.mem_total_size = 0,
+	.mem_block_size = 0
+};
+
+mm_context_t *demuxerInit(void)
+{
+    return mm_module_open(&demuxer_module);
+}
+
+mm_context_t *demuxerDeinit(mm_context_t *p)
+{
+    return mm_module_close(p);
+}
+
+void demuxerOpen(mm_context_t *p, const char* file_name, uint8_t stream_type, uint32_t loop_mode, uint32_t start_time)
+{
+     demuxer_params.start_time = start_time;
+     demuxer_params.stream_type = stream_type;
+     demuxer_params.loop_mode = loop_mode;
+
+    // Copy the file name into the structure
+    strncpy(demuxer_params.record_file_name, file_name, sizeof(demuxer_params.record_file_name) - 1);
+    demuxer_params.record_file_name[sizeof(demuxer_params.record_file_name) - 1] = '\0';
+
+    demuxer_params.mem_total_size = 1 * 1024 * 1024;
+    demuxer_params.mem_block_size = 128;
+
+    mm_module_ctrl(p, CMD_DEMUXER_SET_PARAMS, (int)&demuxer_params);
+    mm_module_ctrl(p, MM_CMD_SET_QUEUE_LEN, 12);
+    mm_module_ctrl(p, MM_CMD_INIT_QUEUE_ITEMS, MMQI_FLAG_DYNAMIC);
+    mm_module_ctrl(p, CMD_DEMUXER_INIT_MEM_POOL, 0);
+    mm_module_ctrl(p, CMD_DEMUXER_OPEN, 0);
+
+    printf("DEMUXER OPENED\r\n");
+}
+
+void demuxerStart(mm_context_t *p)
+{
+    printf("CMD_DEMUXER_STREAM_START\r\n");
+    mm_module_ctrl(p, CMD_DEMUXER_STREAM_START, 0);
+}
+
+void demuxerPause(mm_context_t *p)
+{
+    printf("Set Pause for the MP4\r\n");
+    mm_module_ctrl(p, CMD_DEMUXER_STREAM_PAUSE, 0);
+}
+
+void demuxerResume(mm_context_t *p)
+{
+    printf("Set RESUME for the MP4\r\n");
+    mm_module_ctrl(p, CMD_DEMUXER_STREAM_RESUME, 0);
+}
+

--- a/Arduino_package/hardware/cores/ambpro2/demuxer_drv.h
+++ b/Arduino_package/hardware/cores/ambpro2/demuxer_drv.h
@@ -5,7 +5,7 @@
 
 mm_context_t *demuxerInit(void);
 mm_context_t *demuxerDeinit(mm_context_t *p);
-void demuxerOpen(mm_context_t *p, const char* file_name, uint8_t stream_type, uint32_t loop_mode, uint32_t start_time);
+void demuxerOpen(mm_context_t *p, const char *file_name, uint8_t stream_type, uint32_t loop_mode, uint32_t start_time);
 void demuxerStart(mm_context_t *p);
 void demuxerPause(mm_context_t *p);
 void demuxerResume(mm_context_t *p);

--- a/Arduino_package/hardware/cores/ambpro2/demuxer_drv.h
+++ b/Arduino_package/hardware/cores/ambpro2/demuxer_drv.h
@@ -1,0 +1,13 @@
+#ifndef DEMUXER_DRV_H
+#define DEMUXER_DRV_H
+
+#include "mmf2_module.h"
+
+mm_context_t *demuxerInit(void);
+mm_context_t *demuxerDeinit(mm_context_t *p);
+void demuxerOpen(mm_context_t *p, const char* file_name, uint8_t stream_type, uint32_t loop_mode, uint32_t start_time);
+void demuxerStart(mm_context_t *p);
+void demuxerPause(mm_context_t *p);
+void demuxerResume(mm_context_t *p);
+
+#endif

--- a/Arduino_package/hardware/libraries/Multimedia/examples/DemuxerRTSP/DemuxerRTSP.ino
+++ b/Arduino_package/hardware/libraries/Multimedia/examples/DemuxerRTSP/DemuxerRTSP.ino
@@ -1,0 +1,85 @@
+/*
+ Example guide:
+ TBC
+
+ Default preset configurations for each video channel:
+ Channel 0 : 1920 x 1080 30FPS H264
+ Channel 1 : 1280 x 720  30FPS H264
+ Channel 2 : 1280 x 720  30FPS MJPEG
+
+ Default audio preset configurations:
+ 0 :  8kHz Mono Analog Mic
+ 1 : 16kHz Mono Analog Mic
+ 2 :  8kHz Mono Digital PDM Mic
+ 3 : 16kHz Mono Digital PDM Mic
+
+ LOOP_MODE:
+ 0 : No looping of MP4 file
+ 1 : Looping of MP4 file
+*/
+
+#include "WiFi.h"
+#include "StreamIO.h"
+#include "VideoStream.h"
+#include "Demuxer.h"
+#include "RTSP.h"
+#include "AudioStream.h"
+#include "AudioEncoder.h"
+
+#define CHANNEL   0
+#define LOOP_MODE 1
+
+VideoSetting config(CHANNEL);
+AudioSetting configA(0);
+RTSP rtsp;
+Demuxer demuxer;
+StreamIO demuxerRTSPStreamer(1, 1);    // 1 Input Demuxer -> 1 Output RTSP
+
+char ssid[] = "Network_SSID";    // your network SSID (name)
+char pass[] = "Password";        // your network password
+int status = WL_IDLE_STATUS;
+
+const char* MP4FileName = "filename.mp4";
+
+void setup()
+{
+    Serial.begin(115200);
+
+    // attempt to connect to Wifi network:
+    while (status != WL_CONNECTED) {
+        Serial.print("Attempting to connect to WPA SSID: ");
+        Serial.println(ssid);
+        status = WiFi.begin(ssid, pass);
+
+        // wait 2 seconds for connection:
+        delay(2000);
+    }
+
+    demuxer.begin(MP4FileName, LOOP_MODE);
+
+    // Configure RTSP with identical video and audio format information
+    rtsp.configVideo(config);
+    rtsp.configAudio(configA, CODEC_AAC);
+    rtsp.begin();
+
+    // Configure StreamIO object to stream data from recorded MP4 to RTSP
+    demuxerRTSPStreamer.registerInput(demuxer);
+    demuxerRTSPStreamer.registerOutput(rtsp);
+    if (demuxerRTSPStreamer.begin() != 0) {
+        Serial.println("StreamIO link start failed");
+    }
+}
+
+void loop()
+{
+    if (Serial.available() > 0) {
+        String input = Serial.readString();
+        input.trim();
+
+        if (input.startsWith(String("pause"))) {
+            demuxer.pause();
+        } else if (input.startsWith(String("resume"))) {
+            demuxer.resume();
+        }
+    }
+}

--- a/Arduino_package/hardware/libraries/Multimedia/keywords.txt
+++ b/Arduino_package/hardware/libraries/Multimedia/keywords.txt
@@ -23,6 +23,7 @@ OSD	KEYWORD1
 MotionDetection	KEYWORD1
 MotionDetectionPostProcess	KEYWORD1
 MotionDetectionRegion	KEYWORD1
+Demuxer	KEYWORD1
 
 #######################################
 # AudioDecoder.h Methods (KEYWORD2) & Constants (LITERAL1)
@@ -291,3 +292,12 @@ xMin	KEYWORD2
 xMax	KEYWORD2
 yMin	KEYWORD2
 yMax	KEYWORD2
+
+#######################################
+# Demuxer.h Methods (KEYWORD2) & Constants (LITERAL1)
+#######################################
+
+begin	KEYWORD2
+pause	KEYWORD2
+resume	KEYWORD2
+end	KEYWORD2

--- a/Arduino_package/hardware/libraries/Multimedia/src/Demuxer.cpp
+++ b/Arduino_package/hardware/libraries/Multimedia/src/Demuxer.cpp
@@ -1,0 +1,67 @@
+#include <Arduino.h>
+#include "Demuxer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "demuxer_drv.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+Demuxer::Demuxer(void)
+{
+}
+
+Demuxer::~Demuxer(void)
+{
+    if (_p_mmf_context == NULL) {
+        return;
+    }
+    end();
+    if (demuxerDeinit(_p_mmf_context) == NULL) {
+        _p_mmf_context = NULL;
+    } else {
+        printf("\r\n[ERROR] Demuxer deinit failed\n");
+    }
+}
+
+void Demuxer::begin(const char* MP4FileName, uint32_t loopMode, uint32_t startTime)
+{
+    _p_mmf_context = demuxerInit();
+
+    if (_p_mmf_context == NULL) {
+        printf("\r\n[ERROR] Need Demuxer init first\n");
+    } else {
+        demuxerOpen(_p_mmf_context, MP4FileName, MEDIA_STREAM_TYPE, loopMode, startTime);
+        demuxerStart(_p_mmf_context);
+    }
+}
+
+void Demuxer::pause()
+{
+    if (_p_mmf_context == NULL) {
+        printf("\r\n[ERROR] Need Demuxer init first\n");
+    } else {
+        demuxerPause(_p_mmf_context);
+    }
+}
+
+void Demuxer::resume()
+{
+    if (_p_mmf_context == NULL) {
+        printf("\r\n[ERROR] Need Demuxer init first\n");
+    } else {
+        demuxerResume(_p_mmf_context);
+    }
+}
+
+void Demuxer::end(void)
+{
+    if (_p_mmf_context == NULL) {
+        printf("\r\n[ERROR] Need Demuxer init first\n");
+    }
+    demuxerDeinit(_p_mmf_context);
+}

--- a/Arduino_package/hardware/libraries/Multimedia/src/Demuxer.h
+++ b/Arduino_package/hardware/libraries/Multimedia/src/Demuxer.h
@@ -1,0 +1,30 @@
+#ifndef __DEMUXER_H__
+#define __DEMUXER_H__
+
+#include "VideoStream.h"
+
+// STREAM TYPE
+#define STREAM_AUDIO 0x01
+#define STREAM_VIDEO 0x10
+#define STREAM_ALL   0x11
+
+// LOOP MODE
+#define NO_LOOP 0
+#define LOOP    1
+
+#define MEDIA_STREAM_TYPE STREAM_ALL
+
+class Demuxer: public MMFModule {
+public:
+    Demuxer(void);
+    ~Demuxer(void);
+
+    void begin(const char* MP4FileName, uint32_t loopMode, uint32_t startTime = 0);
+    void pause();
+    void resume();
+    void end(void);
+
+private:
+};
+
+#endif


### PR DESCRIPTION
## Description of Change
- Feature: Add demuxer RTSP example
- API Updates: Demuxer API
This example illustrates the demuxer extracting audio and video streams from the MP4 file save in SD card and the extracted streams are streamed via RTSP.

## Tests and Environments 
- AMB82-mini
- ambpro2_arduino V4.0.9-build20250205
- Arduino IDE 2.3.4
- Windows 10

## Remark related links
Example for issue https://github.com/Ameba-AIoT/ameba-arduino-pro2/issues/284
