### PR TITLE
Add USB Mass Storage Example

### DIFF
--- a/Arduino_package/hardware/libraries/USB/examples/USB_Mass_Storage/USB_Mass_Storage.ino
+++ b/Arduino_package/hardware/libraries/USB/examples/USB_Mass_Storage/USB_Mass_Storage.ino
@@ -1,0 +1,34 @@
+/*
+ * In this example, the device is setup to function as a USB Mass Storage and uses SD card as its physical memory medium.
+ * USB host end can recognize device and write data to and read data from SD card via USB interface.
+ * Connect to PC and use the device.
+
+ * Example guide: TBD
+ */
+
+#include "USBMassStorage.h"
+
+USBMassStorage USBMS;
+
+void setup()
+{
+    Serial.begin(115200);
+    USBMS.USBInit();
+    USBMS.SDIOInit();
+
+    int status = USBMS.USBStatus();
+    Serial.print("Status ");
+    Serial.println(status);
+
+    USBMS.initializeDisk();
+    USBMS.loadUSBMassStorageDriver();
+
+    while (1) {
+        delay(1000);
+    };
+}
+
+void loop()
+{
+    // do nothing
+}

--- a/Arduino_package/hardware/libraries/USB/keywords.txt
+++ b/Arduino_package/hardware/libraries/USB/keywords.txt
@@ -7,6 +7,7 @@
 #######################################
 
 UVCD	KEYWORD1
+USBMassStorage	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -15,6 +16,12 @@ UVCD	KEYWORD1
 stream_config	KEYWORD2
 camera_uvcd	KEYWORD2
 usb_uvcd	KEYWORD2
+USBInit	KEYWORD2
+SDIOInit	KEYWORD2
+USBStatus	KEYWORD2
+initializeDisk	KEYWORD2
+loadUSBMassStorageDriver	KEYWORD2
+USBDeinit	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/Arduino_package/hardware/libraries/USB/src/USBMassStorage.cpp
+++ b/Arduino_package/hardware/libraries/USB/src/USBMassStorage.cpp
@@ -1,0 +1,83 @@
+#include "USBMassStorage.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "msc/inc/usbd_msc.h"
+#include "sdio_combine.h"
+#include "sys_api.h"
+
+// from fatfs_sdcard_api.h
+extern void sd_gpio_init(void);
+extern int usb_sd_init(void);
+extern int usb_sd_deinit(void);
+extern int usb_sd_getcapacity(uint32_t *sector_count);
+extern int usb_sd_readblocks(uint32_t sector, uint8_t *data, uint32_t count);
+extern int usb_sd_writeblocks(uint32_t sector, const uint8_t *data, uint32_t count);
+
+#ifdef __cplusplus
+}
+#endif
+
+void USBMassStorage::USBInit(void)
+{
+    _usb_init();
+}
+
+void USBMassStorage::SDIOInit(void)
+{
+    sd_gpio_init();
+    sdio_driver_init();
+}
+
+int USBMassStorage::USBStatus(void)
+{
+    int status = wait_usb_ready();
+    if (status != USBD_INIT_OK) {
+        if (status == USBD_NOT_ATTACHED) {
+            printf("\r\n NO USB device attached\n");
+        } else {
+            printf("\r\n USB init fail\n");
+        }
+    } else {
+        printf("\r\n USB device attached\n");
+    }
+    return status;
+}
+
+void USBMassStorage::initializeDisk(void)
+{
+
+    disk_operations = (msc_opts *)malloc(sizeof(struct msc_opts));
+    if (disk_operations == NULL) {
+        printf("\r\n disk_operation malloc fail\n");
+    }
+
+    disk_operations->disk_init = usb_sd_init;
+    disk_operations->disk_deinit = usb_sd_deinit;
+    disk_operations->disk_getcapacity = usb_sd_getcapacity;
+    disk_operations->disk_read = usb_sd_readblocks;
+    disk_operations->disk_write = usb_sd_writeblocks;
+}
+
+void USBMassStorage::loadUSBMassStorageDriver(void)
+{
+    int status = usbd_msc_init(MSC_NBR_BUFHD, MSC_BUFLEN, disk_operations);
+    if (status) {
+        printf("USB MSC driver load fail.\n");
+    } else {
+        printf("USB MSC driver load done, Available heap [0x%x]\n", xPortGetFreeHeapSize());
+    }
+}
+
+void USBMassStorage::USBDeinit(void)
+{
+    usbd_msc_deinit();
+    extern void _usb_deinit(void);
+    _usb_deinit();
+    if (disk_operations) {
+        free(disk_operations);
+        disk_operations = NULL;
+    }
+}

--- a/Arduino_package/hardware/libraries/USB/src/USBMassStorage.h
+++ b/Arduino_package/hardware/libraries/USB/src/USBMassStorage.h
@@ -1,0 +1,19 @@
+#ifndef __USBMASSSTORAGE_H__
+#define __USBMASSSTORAGE_H__
+
+#include <Arduino.h>
+
+class USBMassStorage {
+
+public:
+    void USBInit(void);
+    void SDIOInit(void);
+    int USBStatus(void);
+    void initializeDisk(void);
+    void loadUSBMassStorageDriver(void);
+    void USBDeinit(void);
+
+private:
+    struct msc_opts *disk_operations = NULL;
+};
+#endif


### PR DESCRIPTION
## Description of Change
- Add USB Mass Storage Example

## Tests and Environments 
- AMB82-mini
- ambpro2_arduino V4.0.9
- Arduino IDE 2.3.4
- Windows 10