### PR TITLE
fix(spi): update end api to ensure compatibility with standard Arduino SPI

### DIFF
--- a/Arduino_package/hardware/libraries/SPI/src/SPI.cpp
+++ b/Arduino_package/hardware/libraries/SPI/src/SPI.cpp
@@ -235,6 +235,11 @@ void SPIClass::setBitOrder(BitOrder order)
     setBitOrder(_pinSS, order);
 }
 
+void SPIClass::setDataMode(uint8_t dataMode)
+{
+    setDataMode(_dataBits, dataMode, _SPI_Mode);
+}
+
 void SPIClass::setDataMode(uint8_t bits, uint8_t dataMode, char SPI_mode)
 {
     _dataBits = bits;
@@ -268,14 +273,27 @@ void SPIClass::setDefaultFrequency(int frequency)
     _defaultFrequency = frequency;
 }
 
+void SPIClass::end(void)
+{
+    // Use the mode recorded at begin() time
+    end(_SPI_Mode);
+}
+
 void SPIClass::end(char SPI_mode)
 {
+    if (!_initStatus) {
+        return;    // guard against double-free
+    }
+
     _SPI_Mode = SPI_mode;
 
     if (_SPI_Mode == SPI_MODE_MASTER) {
         spi_free(pSpiMaster);
     } else if (_SPI_Mode == SPI_MODE_SLAVE) {
         spi_free(pSpiSlave);
+    } else {
+        amb_ard_printf(ARD_LOG_ERR, "\r\n[ERROR] SPI end: invalid SPI mode\n");
+        return;
     }
 
     _initStatus = false;

--- a/Arduino_package/hardware/libraries/SPI/src/SPI.h
+++ b/Arduino_package/hardware/libraries/SPI/src/SPI.h
@@ -132,15 +132,18 @@ public:
     void setBitOrder(BitOrder order);
 
     // Set data mode
-    void setDataMode(uint8_t pin, uint8_t dataMode, char SPI_mode = SPI_MODE_MASTER);
-    // void setDataMode(uint8_t _mode);
+    // Arduino-standard: set data mode only, keep current data bits
+    void setDataMode(uint8_t _mode);
+    // Ameba extended: set data bits + data mode + master/slave role
+    void setDataMode(uint8_t bits, uint8_t dataMode, char SPI_mode = SPI_MODE_MASTER);
 
     // Set to correct clock speed (no effect on Ameba)
     void setClockDivider(uint8_t pin, uint8_t divider);
     void setClockDivider(uint8_t div);
 
     // Stop SPI master/slave mode
-    void end(char SPI_mode);
+    void end(void);             // NEW: Arduino-standard, ends current mode
+    void end(char SPI_mode);    // Legacy Ameba API (kept for compatibility)
 
     /* extend api added by RTK */
     // Set default SPI frequency


### PR DESCRIPTION
## Description of Change
- Feature: 
- API Updates: update end api to ensure compatibility with standard Arduino SPI
- Misc:

## Tests and Environments 
- AMB82-mini
- ambpro2_arduino V4.1.1
- Arduino IDE 2.3.7
- Windows 11
