### PR TITLE
fix(video): Modify RecordMP4 with NTPClient Examples

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "conventionalCommits.scopes": [
+        "video"
+    ]
+}

--- a/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/AudioOnlyWithNTPClient/AudioOnlyWithNTPClient.ino
+++ b/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/AudioOnlyWithNTPClient/AudioOnlyWithNTPClient.ino
@@ -40,7 +40,7 @@ MP4Recording mp4;
 StreamIO audioStreamer1(1, 1);    // 1 Input Audio -> 1 Output AAC
 StreamIO audioStreamer2(1, 1);    // 1 Input AAC -> 1 Output MP4
 
-#define TOTAL_FILES 1
+#define TOTAL_FILES          1
 #define RECORDING_DURATION_S 30
 
 volatile uint32_t fileCloseCount = 0;
@@ -189,8 +189,7 @@ void updateFileTimestamp(uint32_t index, unsigned long epoch)
             sizeof(path),
             "%s%s.mp4",
             fs.getRootPath(),
-            baseFileName.c_str()
-        );
+            baseFileName.c_str());
     } else {
         snprintf(
             path,
@@ -198,8 +197,7 @@ void updateFileTimestamp(uint32_t index, unsigned long epoch)
             "%s%s_%lu.mp4",
             fs.getRootPath(),
             baseFileName.c_str(),
-            (unsigned long)index
-        );
+            (unsigned long)index);
     }
 
     Serial.print("Updating: ");

--- a/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/AudioOnlyWithNTPClient/AudioOnlyWithNTPClient.ino
+++ b/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/AudioOnlyWithNTPClient/AudioOnlyWithNTPClient.ino
@@ -40,7 +40,12 @@ MP4Recording mp4;
 StreamIO audioStreamer1(1, 1);    // 1 Input Audio -> 1 Output AAC
 StreamIO audioStreamer2(1, 1);    // 1 Input AAC -> 1 Output MP4
 
-bool updatemodifiedtime = false;
+#define TOTAL_FILES 1
+#define RECORDING_DURATION_S 30
+
+volatile uint32_t fileCloseCount = 0;
+volatile unsigned long fileCloseTimestamps[TOTAL_FILES];
+bool timestampsWritten = false;
 
 void setup()
 {
@@ -53,6 +58,15 @@ void setup()
     }
     timeClient.begin();
 
+    Serial.println("Synchronizing NTP...");
+
+    while (!timeClient.forceUpdate()) {
+        Serial.println("NTP sync failed, retrying...");
+        delay(1000);
+    }
+
+    Serial.println("NTP synchronized");
+
     // Configure audio peripheral for audio data output
     audio.configAudio(configA);
     audio.begin();
@@ -62,10 +76,11 @@ void setup()
 
     // Configure MP4 recording settings
     mp4.configAudio(configA, CODEC_AAC);
-    mp4.setRecordingDuration(30);
-    mp4.setRecordingFileCount(1);
+    mp4.setRecordingDuration(RECORDING_DURATION_S);
+    mp4.setRecordingFileCount(TOTAL_FILES);
     mp4.setRecordingFileName("TestRecordingAudioOnly");
     mp4.setRecordingDataType(STORAGE_AUDIO);    // Set MP4 to record audio only
+    mp4.setRecordingStopCallback(MP4FileClosedCb);
 
     // Configure StreamIO object to stream data from audio channel to AAC encoder
     audioStreamer1.registerInput(audio);
@@ -84,33 +99,41 @@ void setup()
     // Start recording MP4 data to SD card
     mp4.begin();
 
+    if (!fs.begin()) {
+        Serial.println("ERROR: FATFS initialization failed");
+
+        while (1) {
+            delay(1000);
+        }
+    }
+
+    Serial.print("FATFS root: ");
+    Serial.println(fs.getRootPath());
+
     delay(1000);
     printInfo();
 }
 
 void loop()
 {
-    // For updating last modified time after recording stop
-    int state = (int)(mp4.getRecordingState());
-    if (state == 0 && updatemodifiedtime == false) {
-        timeClient.update();
+    if ((fileCloseCount >= TOTAL_FILES) && (mp4.getRecordingState() == 0) && (timestampsWritten == false)) {
 
-        uint16_t year = (uint16_t)timeClient.getYear();
-        uint16_t month = (uint16_t)timeClient.getMonth();
-        uint16_t date = (uint16_t)timeClient.getMonthDay();
-        uint16_t hour = (uint16_t)timeClient.getHours();
-        uint16_t minute = (uint16_t)timeClient.getMinutes();
-        uint16_t second = (uint16_t)timeClient.getSeconds();
+        Serial.println();
+        Serial.println("Updating timestamps...");
 
-        sprintf(path, "%s%s%s", fs.getRootPath(), mp4.getRecordingFileName().c_str(), ".mp4");
-        fs.begin();
-        fs.setLastModTime(path, year, month, date, hour, minute, second);
+        for (uint32_t i = 0; i < TOTAL_FILES; i++) {
+
+            unsigned long timestamp = fileCloseTimestamps[i];
+
+            updateFileTimestamp(i, timestamp);
+        }
+
+        timestampsWritten = true;
+
         fs.end();
-        updatemodifiedtime = true;
-    } else if (state == 1 && updatemodifiedtime == true) {
-        updatemodifiedtime = false;
     }
-    delay(100);
+
+    delay(20);
 }
 
 void printInfo(void)
@@ -123,4 +146,98 @@ void printInfo(void)
     audio.printInfo();
     Serial.println("- MP4 Recording Information -");
     mp4.printInfo();
+}
+
+int MP4FileClosedCb(void *parm)
+{
+    uint32_t index = fileCloseCount;
+
+    if (fileCloseCount < TOTAL_FILES) {
+
+        // Capture NTP-synchronized clock at actual MP4 stop event
+        fileCloseTimestamps[index] = timeClient.getEpochTime();
+
+        fileCloseCount = index + 1;
+    }
+
+    return 0;
+}
+
+void updateFileTimestamp(uint32_t index, unsigned long epoch)
+{
+    time_t fileTime = (time_t)epoch;
+    struct tm *timeinfo = gmtime(&fileTime);
+
+    if (timeinfo == NULL) {
+        Serial.println("ERROR: Time conversion failed");
+        return;
+    }
+
+    uint16_t year = timeinfo->tm_year + 1900;
+    uint16_t month = timeinfo->tm_mon + 1;
+    uint16_t day = timeinfo->tm_mday;
+    uint16_t hour = timeinfo->tm_hour;
+    uint16_t minute = timeinfo->tm_min;
+    uint16_t second = timeinfo->tm_sec;
+
+    String baseFileName = mp4.getRecordingFileName();
+    uint32_t fileCount = mp4.getRecordingFileCount();
+
+    if (fileCount == 1) {
+        snprintf(
+            path,
+            sizeof(path),
+            "%s%s.mp4",
+            fs.getRootPath(),
+            baseFileName.c_str()
+        );
+    } else {
+        snprintf(
+            path,
+            sizeof(path),
+            "%s%s_%lu.mp4",
+            fs.getRootPath(),
+            baseFileName.c_str(),
+            (unsigned long)index
+        );
+    }
+
+    Serial.print("Updating: ");
+    Serial.println(path);
+
+    char timeBuffer[64];
+
+    snprintf(
+        timeBuffer,
+        sizeof(timeBuffer),
+        "Close time: %04u-%02u-%02u %02u:%02u:%02u",
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second);
+
+    Serial.println(timeBuffer);
+
+    if (!fs.exists(path)) {
+        Serial.println("ERROR: File not found");
+        return;
+    }
+
+    int ret = fs.setLastModTime(
+        path,
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second);
+
+    if (ret == 0) {
+        Serial.println("Timestamp updated successfully");
+    } else {
+        Serial.print("setLastModTime failed: ");
+        Serial.println(ret);
+    }
 }

--- a/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/AudioOnlyWithNTPClient/AudioOnlyWithNTPClient.ino
+++ b/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/AudioOnlyWithNTPClient/AudioOnlyWithNTPClient.ino
@@ -148,7 +148,7 @@ void printInfo(void)
     mp4.printInfo();
 }
 
-int MP4FileClosedCb(void *parm)
+int MP4FileClosedCb(void *param)
 {
     uint32_t index = fileCloseCount;
 

--- a/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/DoubleVideoWithAudioAndNTPClient/DoubleVideoWithAudioAndNTPClient.ino
+++ b/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/DoubleVideoWithAudioAndNTPClient/DoubleVideoWithAudioAndNTPClient.ino
@@ -50,8 +50,21 @@ MP4Recording mp4_1;
 MP4Recording mp4_2;
 StreamIO audioStreamer(1, 1);    // 1 Input Audio -> 1 Output AAC
 StreamIO avMixStreamer(3, 2);    // 3 Input Video1 + Video2 + Audio -> 2 Output MP4_1 + MP4_2
-bool updatemodifiedtime1 = false;
-bool updatemodifiedtime2 = false;
+
+#define TOTAL_FILES_1 1
+#define TOTAL_FILES_2 1
+#define RECORDING_DURATION_S_1 15
+#define RECORDING_DURATION_S_2 30
+
+volatile uint32_t fileCloseCount1 = 0;
+volatile uint32_t fileCloseCount2 = 0;
+
+volatile unsigned long fileCloseTimestamps1[TOTAL_FILES_1];
+volatile unsigned long fileCloseTimestamps2[TOTAL_FILES_2];
+
+bool timestampsWritten1 = false;
+bool timestampsWritten2 = false;
+bool fsEnded = false;
 
 void setup()
 {
@@ -63,6 +76,15 @@ void setup()
         Serial.print(".");
     }
     timeClient.begin();
+
+    Serial.println("Synchronizing NTP...");
+
+    while (!timeClient.forceUpdate()) {
+        Serial.println("NTP sync failed, retrying...");
+        delay(1000);
+    }
+
+    Serial.println("NTP synchronized");
 
     // Configure both camera video channels with corresponding video format information
     Camera.configVideoChannel(0, configV1);
@@ -80,15 +102,17 @@ void setup()
     // Configure MP4 recording settings
     mp4_1.configVideo(configV1);
     mp4_1.configAudio(configA, CODEC_AAC);
-    mp4_1.setRecordingDuration(15);
-    mp4_1.setRecordingFileCount(1);
+    mp4_1.setRecordingDuration(RECORDING_DURATION_S_1);
+    mp4_1.setRecordingFileCount(TOTAL_FILES_1);
     mp4_1.setRecordingFileName("TestRecordingAudioVideo1");
+    mp4_1.setRecordingStopCallback(MP4FileClosedCb1);
 
     mp4_2.configVideo(configV2);
     mp4_2.configAudio(configA, CODEC_AAC);
-    mp4_2.setRecordingDuration(30);
-    mp4_2.setRecordingFileCount(1);
+    mp4_2.setRecordingDuration(RECORDING_DURATION_S_2);
+    mp4_2.setRecordingFileCount(TOTAL_FILES_2);
     mp4_2.setRecordingFileName("TestRecordingAudioVideo2");
+    mp4_2.setRecordingStopCallback(MP4FileClosedCb2);
 
     // Configure StreamIO object to stream data from audio channel to AAC encoder
     audioStreamer.registerInput(audio);
@@ -114,54 +138,56 @@ void setup()
     mp4_1.begin();
     mp4_2.begin();
 
-    fs.begin();
+    if (!fs.begin()) {
+        Serial.println("ERROR: FATFS initialization failed");
+
+        while (1) {
+            delay(1000);
+        }
+    }
+
+    Serial.print("FATFS root: ");
+    Serial.println(fs.getRootPath());
+
     delay(1000);
     printInfo();
 }
 
 void loop()
 {
-    uint16_t year, month, date, hour, minute, second;
+    if ((fileCloseCount1 >= TOTAL_FILES_1) && (mp4_1.getRecordingState() == 0) && (timestampsWritten1 == false)) {
 
-    // For updating last modified time after recording stop
-    int state1 = (int)(mp4_1.getRecordingState());
-    if (state1 == 0 && updatemodifiedtime1 == false) {
-        timeClient.update();
+        Serial.println();
+        Serial.println("Updating timestamps (recording 1)...");
 
-        year = (uint16_t)timeClient.getYear();
-        month = (uint16_t)timeClient.getMonth();
-        date = (uint16_t)timeClient.getMonthDay();
-        hour = (uint16_t)timeClient.getHours();
-        minute = (uint16_t)timeClient.getMinutes();
-        second = (uint16_t)timeClient.getSeconds();
+        for (uint32_t i = 0; i < TOTAL_FILES_1; i++) {
+            updateFileTimestamp(mp4_1, path1, i, fileCloseTimestamps1[i]);
+        }
 
-        sprintf(path1, "%s%s%s", fs.getRootPath(), mp4_1.getRecordingFileName().c_str(), ".mp4");
-        fs.begin();
-        fs.setLastModTime(path1, year, month, date, hour, minute, second);
-        updatemodifiedtime1 = true;
-    } else if (state1 == 1 && updatemodifiedtime1 == true) {
-        updatemodifiedtime1 = false;
+        timestampsWritten1 = true;
     }
 
-    int state2 = (int)(mp4_2.getRecordingState());
-    if (state2 == 0 && updatemodifiedtime2 == false) {
-        timeClient.update();
+    // Update last modified time for recording 2 after it stops
+    if ((fileCloseCount2 >= TOTAL_FILES_2) && (mp4_2.getRecordingState() == 0) && (timestampsWritten2 == false)) {
 
-        year = (uint16_t)timeClient.getYear();
-        month = (uint16_t)timeClient.getMonth();
-        date = (uint16_t)timeClient.getMonthDay();
-        hour = (uint16_t)timeClient.getHours();
-        minute = (uint16_t)timeClient.getMinutes();
-        second = (uint16_t)timeClient.getSeconds();
+        Serial.println();
+        Serial.println("Updating timestamps (recording 2)...");
 
-        sprintf(path2, "%s%s%s", fs.getRootPath(), mp4_2.getRecordingFileName().c_str(), ".mp4");
-        fs.begin();
-        fs.setLastModTime(path2, year, month, date, hour, minute, second);
-        updatemodifiedtime2 = true;
-    } else if (state2 == 1 && updatemodifiedtime2 == true) {
-        updatemodifiedtime2 = false;
+        for (uint32_t i = 0; i < TOTAL_FILES_2; i++) {
+            updateFileTimestamp(mp4_2, path2, i, fileCloseTimestamps1[i]);
+        }
+
+        timestampsWritten2 = true;
     }
-    delay(100);
+
+    // Unmount the SD card once both recordings' timestamps are updated
+    if ((timestampsWritten1 == true) && (timestampsWritten2 == true) && (fsEnded == false)) {
+
+        fs.end();
+        fsEnded = true;
+    }
+
+    delay(20);
 }
 
 void printInfo(void)
@@ -179,4 +205,113 @@ void printInfo(void)
     mp4_1.printInfo();
     Serial.println("- MP4 Recording Information 2-");
     mp4_2.printInfo();
+}
+
+int MP4FileClosedCb1(void *parm)
+{
+    uint32_t index = fileCloseCount1;
+
+    if (index < TOTAL_FILES_1) {
+
+        // Capture NTP-synchronized clock at actual MP4 stop event
+        fileCloseTimestamps1[index] = timeClient.getEpochTime();
+
+        fileCloseCount1 = index + 1;
+    }
+
+    return 0;
+}
+
+int MP4FileClosedCb2(void *parm)
+{
+    uint32_t index = fileCloseCount2;
+
+    if (index < TOTAL_FILES_2) {
+
+        // Capture NTP-synchronized clock at actual MP4 stop event
+        fileCloseTimestamps2[index] = timeClient.getEpochTime();
+
+        fileCloseCount2 = index + 1;
+    }
+
+    return 0;
+}
+
+void updateFileTimestamp(MP4Recording &recorder, char *path, uint32_t index, unsigned long epoch)
+{
+    time_t fileTime = (time_t)epoch;
+    struct tm *timeinfo = gmtime(&fileTime);
+
+    if (timeinfo == NULL) {
+        Serial.println("ERROR: Time conversion failed");
+        return;
+    }
+
+    uint16_t year = timeinfo->tm_year + 1900;
+    uint16_t month = timeinfo->tm_mon + 1;
+    uint16_t day = timeinfo->tm_mday;
+    uint16_t hour = timeinfo->tm_hour;
+    uint16_t minute = timeinfo->tm_min;
+    uint16_t second = timeinfo->tm_sec;
+
+    String baseFileName = recorder.getRecordingFileName();
+    uint32_t fileCount = recorder.getRecordingFileCount();
+
+    if (fileCount == 1) {
+        snprintf(
+            path,
+            128,
+            "%s%s.mp4",
+            fs.getRootPath(),
+            baseFileName.c_str()
+        );
+    } else {
+        snprintf(
+            path,
+            128,
+            "%s%s_%lu.mp4",
+            fs.getRootPath(),
+            baseFileName.c_str(),
+            (unsigned long)index
+        );
+    }
+
+    Serial.print("Updating: ");
+    Serial.println(path);
+
+    char timeBuffer[64];
+
+    snprintf(
+        timeBuffer,
+        sizeof(timeBuffer),
+        "Close time: %04u-%02u-%02u %02u:%02u:%02u",
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second);
+
+    Serial.println(timeBuffer);
+
+    if (!fs.exists(path)) {
+        Serial.println("ERROR: File not found");
+        return;
+    }
+
+    int ret = fs.setLastModTime(
+        path,
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second);
+
+    if (ret == 0) {
+        Serial.println("Timestamp updated successfully");
+    } else {
+        Serial.print("setLastModTime failed: ");
+        Serial.println(ret);
+    }
 }

--- a/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/DoubleVideoWithAudioAndNTPClient/DoubleVideoWithAudioAndNTPClient.ino
+++ b/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/DoubleVideoWithAudioAndNTPClient/DoubleVideoWithAudioAndNTPClient.ino
@@ -207,7 +207,7 @@ void printInfo(void)
     mp4_2.printInfo();
 }
 
-int MP4FileClosedCb1(void *parm)
+int MP4FileClosedCb1(void *param)
 {
     uint32_t index = fileCloseCount1;
 
@@ -222,7 +222,7 @@ int MP4FileClosedCb1(void *parm)
     return 0;
 }
 
-int MP4FileClosedCb2(void *parm)
+int MP4FileClosedCb2(void *param)
 {
     uint32_t index = fileCloseCount2;
 

--- a/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/DoubleVideoWithAudioAndNTPClient/DoubleVideoWithAudioAndNTPClient.ino
+++ b/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/DoubleVideoWithAudioAndNTPClient/DoubleVideoWithAudioAndNTPClient.ino
@@ -51,8 +51,8 @@ MP4Recording mp4_2;
 StreamIO audioStreamer(1, 1);    // 1 Input Audio -> 1 Output AAC
 StreamIO avMixStreamer(3, 2);    // 3 Input Video1 + Video2 + Audio -> 2 Output MP4_1 + MP4_2
 
-#define TOTAL_FILES_1 1
-#define TOTAL_FILES_2 1
+#define TOTAL_FILES_1          1
+#define TOTAL_FILES_2          1
 #define RECORDING_DURATION_S_1 15
 #define RECORDING_DURATION_S_2 30
 
@@ -263,8 +263,7 @@ void updateFileTimestamp(MP4Recording &recorder, char *path, uint32_t index, uns
             128,
             "%s%s.mp4",
             fs.getRootPath(),
-            baseFileName.c_str()
-        );
+            baseFileName.c_str());
     } else {
         snprintf(
             path,
@@ -272,8 +271,7 @@ void updateFileTimestamp(MP4Recording &recorder, char *path, uint32_t index, uns
             "%s%s_%lu.mp4",
             fs.getRootPath(),
             baseFileName.c_str(),
-            (unsigned long)index
-        );
+            (unsigned long)index);
     }
 
     Serial.print("Updating: ");

--- a/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/SingleVideoWithAudioAndNTPClient/SingleVideoWithAudioAndNTPClient.ino
+++ b/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/SingleVideoWithAudioAndNTPClient/SingleVideoWithAudioAndNTPClient.ino
@@ -48,7 +48,7 @@ MP4Recording mp4;
 StreamIO audioStreamer(1, 1);    // 1 Input Audio -> 1 Output AAC
 StreamIO avMixStreamer(2, 1);    // 2 Input Video + Audio -> 1 Output MP4
 
-#define TOTAL_FILES 1
+#define TOTAL_FILES          1
 #define RECORDING_DURATION_S 30
 
 volatile uint32_t fileCloseCount = 0;
@@ -145,7 +145,7 @@ void loop()
         }
 
         timestampsWritten = true;
-        
+
         fs.end();
     }
 
@@ -207,8 +207,7 @@ void updateFileTimestamp(uint32_t index, unsigned long epoch)
             sizeof(path),
             "%s%s.mp4",
             fs.getRootPath(),
-            baseFileName.c_str()
-        );
+            baseFileName.c_str());
     } else {
         snprintf(
             path,
@@ -216,8 +215,7 @@ void updateFileTimestamp(uint32_t index, unsigned long epoch)
             "%s%s_%lu.mp4",
             fs.getRootPath(),
             baseFileName.c_str(),
-            (unsigned long)index
-        );
+            (unsigned long)index);
     }
 
     Serial.print("Updating: ");

--- a/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/SingleVideoWithAudioAndNTPClient/SingleVideoWithAudioAndNTPClient.ino
+++ b/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/SingleVideoWithAudioAndNTPClient/SingleVideoWithAudioAndNTPClient.ino
@@ -166,7 +166,7 @@ void printInfo(void)
     mp4.printInfo();
 }
 
-int MP4FileClosedCb(void *parm)
+int MP4FileClosedCb(void *param)
 {
     uint32_t index = fileCloseCount;
 

--- a/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/SingleVideoWithAudioAndNTPClient/SingleVideoWithAudioAndNTPClient.ino
+++ b/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/SingleVideoWithAudioAndNTPClient/SingleVideoWithAudioAndNTPClient.ino
@@ -47,7 +47,13 @@ AAC aac;
 MP4Recording mp4;
 StreamIO audioStreamer(1, 1);    // 1 Input Audio -> 1 Output AAC
 StreamIO avMixStreamer(2, 1);    // 2 Input Video + Audio -> 1 Output MP4
-bool updatemodifiedtime = false;
+
+#define TOTAL_FILES 1
+#define RECORDING_DURATION_S 30
+
+volatile uint32_t fileCloseCount = 0;
+volatile unsigned long fileCloseTimestamps[TOTAL_FILES];
+bool timestampsWritten = false;
 
 void setup()
 {
@@ -59,6 +65,15 @@ void setup()
         Serial.print(".");
     }
     timeClient.begin();
+
+    Serial.println("Synchronizing NTP...");
+
+    while (!timeClient.forceUpdate()) {
+        Serial.println("NTP sync failed, retrying...");
+        delay(1000);
+    }
+
+    Serial.println("NTP synchronized");
 
     // Configure camera video channel with video format information
     Camera.configVideoChannel(CHANNEL, configV);
@@ -75,9 +90,10 @@ void setup()
     // Configure MP4 recording settings
     mp4.configVideo(configV);
     mp4.configAudio(configA, CODEC_AAC);
-    mp4.setRecordingDuration(30);
-    mp4.setRecordingFileCount(1);
+    mp4.setRecordingDuration(RECORDING_DURATION_S);
+    mp4.setRecordingFileCount(TOTAL_FILES);
     mp4.setRecordingFileName("TestRecordingAudioVideo");
+    mp4.setRecordingStopCallback(MP4FileClosedCb);
 
     // Configure StreamIO object to stream data from audio channel to AAC encoder
     audioStreamer.registerInput(audio);
@@ -99,34 +115,41 @@ void setup()
     // Start recording MP4 data to SD card
     mp4.begin();
 
-    // Print information
+    if (!fs.begin()) {
+        Serial.println("ERROR: FATFS initialization failed");
+
+        while (1) {
+            delay(1000);
+        }
+    }
+
+    Serial.print("FATFS root: ");
+    Serial.println(fs.getRootPath());
+
     delay(1000);
     printInfo();
 }
 
 void loop()
 {
-    // For updating last modified time after recording stop
-    int state = (int)mp4.getRecordingState();
-    if (state == 0 && updatemodifiedtime == false) {
-        timeClient.update();
+    if ((fileCloseCount >= TOTAL_FILES) && (mp4.getRecordingState() == 0) && (timestampsWritten == false)) {
 
-        uint16_t year = (uint16_t)timeClient.getYear();
-        uint16_t month = (uint16_t)timeClient.getMonth();
-        uint16_t date = (uint16_t)timeClient.getMonthDay();
-        uint16_t hour = (uint16_t)timeClient.getHours();
-        uint16_t minute = (uint16_t)timeClient.getMinutes();
-        uint16_t second = (uint16_t)timeClient.getSeconds();
+        Serial.println();
+        Serial.println("Updating timestamps...");
 
-        sprintf(path, "%s%s%s", fs.getRootPath(), mp4.getRecordingFileName().c_str(), ".mp4");
-        fs.begin();
-        fs.setLastModTime(path, year, month, date, hour, minute, second);
+        for (uint32_t i = 0; i < TOTAL_FILES; i++) {
+
+            unsigned long timestamp = fileCloseTimestamps[i];
+
+            updateFileTimestamp(i, timestamp);
+        }
+
+        timestampsWritten = true;
+        
         fs.end();
-        updatemodifiedtime = true;
-    } else if (state == 1 && updatemodifiedtime == true) {
-        updatemodifiedtime = false;
     }
-    delay(100);
+
+    delay(20);
 }
 
 void printInfo(void)
@@ -141,4 +164,98 @@ void printInfo(void)
     audio.printInfo();
     Serial.println("- MP4 Recording Information -");
     mp4.printInfo();
+}
+
+int MP4FileClosedCb(void *parm)
+{
+    uint32_t index = fileCloseCount;
+
+    if (index < TOTAL_FILES) {
+
+        // Capture NTP-synchronized clock at actual MP4 stop event
+        fileCloseTimestamps[index] = timeClient.getEpochTime();
+
+        fileCloseCount = index + 1;
+    }
+
+    return 0;
+}
+
+void updateFileTimestamp(uint32_t index, unsigned long epoch)
+{
+    time_t fileTime = (time_t)epoch;
+    struct tm *timeinfo = gmtime(&fileTime);
+
+    if (timeinfo == NULL) {
+        Serial.println("ERROR: Time conversion failed");
+        return;
+    }
+
+    uint16_t year = timeinfo->tm_year + 1900;
+    uint16_t month = timeinfo->tm_mon + 1;
+    uint16_t day = timeinfo->tm_mday;
+    uint16_t hour = timeinfo->tm_hour;
+    uint16_t minute = timeinfo->tm_min;
+    uint16_t second = timeinfo->tm_sec;
+
+    String baseFileName = mp4.getRecordingFileName();
+    uint32_t fileCount = mp4.getRecordingFileCount();
+
+    if (fileCount == 1) {
+        snprintf(
+            path,
+            sizeof(path),
+            "%s%s.mp4",
+            fs.getRootPath(),
+            baseFileName.c_str()
+        );
+    } else {
+        snprintf(
+            path,
+            sizeof(path),
+            "%s%s_%lu.mp4",
+            fs.getRootPath(),
+            baseFileName.c_str(),
+            (unsigned long)index
+        );
+    }
+
+    Serial.print("Updating: ");
+    Serial.println(path);
+
+    char timeBuffer[64];
+
+    snprintf(
+        timeBuffer,
+        sizeof(timeBuffer),
+        "Close time: %04u-%02u-%02u %02u:%02u:%02u",
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second);
+
+    Serial.println(timeBuffer);
+
+    if (!fs.exists(path)) {
+        Serial.println("ERROR: File not found");
+        return;
+    }
+
+    int ret = fs.setLastModTime(
+        path,
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second);
+
+    if (ret == 0) {
+        Serial.println("Timestamp updated successfully");
+    } else {
+        Serial.print("setLastModTime failed: ");
+        Serial.println(ret);
+    }
 }

--- a/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/VideoOnlyWithNTPClient/VideoOnlyWithNTPClient.ino
+++ b/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/VideoOnlyWithNTPClient/VideoOnlyWithNTPClient.ino
@@ -23,7 +23,7 @@ WiFiUDP ntpUDP;
 
 AmebaFatFS fs;
 
-#define TOTAL_FILES 1
+#define TOTAL_FILES          1
 #define RECORDING_DURATION_S 30
 
 volatile uint32_t fileCloseCount = 0;
@@ -181,8 +181,7 @@ void updateFileTimestamp(uint32_t index, unsigned long epoch)
             sizeof(path),
             "%s%s.mp4",
             fs.getRootPath(),
-            baseFileName.c_str()
-        );
+            baseFileName.c_str());
     } else {
         snprintf(
             path,
@@ -190,8 +189,7 @@ void updateFileTimestamp(uint32_t index, unsigned long epoch)
             "%s%s_%lu.mp4",
             fs.getRootPath(),
             baseFileName.c_str(),
-            (unsigned long)index
-        );
+            (unsigned long)index);
     }
 
     Serial.print("Updating: ");

--- a/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/VideoOnlyWithNTPClient/VideoOnlyWithNTPClient.ino
+++ b/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/VideoOnlyWithNTPClient/VideoOnlyWithNTPClient.ino
@@ -23,6 +23,13 @@ WiFiUDP ntpUDP;
 
 AmebaFatFS fs;
 
+#define TOTAL_FILES 1
+#define RECORDING_DURATION_S 30
+
+volatile uint32_t fileCloseCount = 0;
+
+volatile unsigned long fileCloseTimestamps[TOTAL_FILES];
+bool timestampsWritten = false;
 // You can specify the time server pool and the offset (in seconds, can be
 // changed later with setTimeOffset() ). Additionally you can specify the
 // update interval (in milliseconds, can be changed using setUpdateInterval() ).
@@ -48,6 +55,15 @@ void setup()
     }
     timeClient.begin();
 
+    Serial.println("Synchronizing NTP...");
+
+    while (!timeClient.forceUpdate()) {
+        Serial.println("NTP sync failed, retrying...");
+        delay(1000);
+    }
+
+    Serial.println("NTP synchronized");
+
     // Configure camera video channel with video format information
     Camera.configVideoChannel(CHANNEL, config);
     Camera.videoInit();
@@ -55,10 +71,11 @@ void setup()
     // Configure MP4 with identical video format information
     // Configure MP4 recording settings
     mp4.configVideo(config);
-    mp4.setRecordingDuration(30);
-    mp4.setRecordingFileCount(1);
-    mp4.setRecordingFileName("TestRecordingVideoOnly");
+    mp4.setRecordingDuration(RECORDING_DURATION_S);
+    mp4.setRecordingFileCount(TOTAL_FILES);
+    mp4.setRecordingFileName("TestRecording");
     mp4.setRecordingDataType(STORAGE_VIDEO);    // Set MP4 to record video only
+    mp4.setRecordingStopCallback(MP4FileClosed);
 
     // Configure StreamIO object to stream data from video channel to MP4 recording
     videoStreamer.registerInput(Camera.getStream(CHANNEL));
@@ -69,6 +86,18 @@ void setup()
 
     // Start data stream from video channel
     Camera.channelBegin(CHANNEL);
+
+    if (!fs.begin()) {
+        Serial.println("ERROR: FATFS initialization failed");
+
+        while (1) {
+            delay(1000);
+        }
+    }
+
+    Serial.print("FATFS root: ");
+    Serial.println(fs.getRootPath());
+
     // Start recording MP4 data to SD card
     mp4.begin();
 
@@ -76,29 +105,28 @@ void setup()
     printInfo();
 }
 
+
+
 void loop()
 {
-    // For updating last modified time after recording stop
-    int state = (int)mp4.getRecordingState();
-    if (state == 0 && updatemodifiedtime == false) {
-        timeClient.update();
+    if ((fileCloseCount >= TOTAL_FILES) && (mp4.getRecordingState() == 0) && (timestampsWritten == false)) {
 
-        uint16_t year = (uint16_t)timeClient.getYear();
-        uint16_t month = (uint16_t)timeClient.getMonth();
-        uint16_t date = (uint16_t)timeClient.getMonthDay();
-        uint16_t hour = (uint16_t)timeClient.getHours();
-        uint16_t minute = (uint16_t)timeClient.getMinutes();
-        uint16_t second = (uint16_t)timeClient.getSeconds();
+        Serial.println();
+        Serial.println("Updating timestamps...");
 
-        sprintf(path, "%s%s%s", fs.getRootPath(), mp4.getRecordingFileName().c_str(), ".mp4");
-        fs.begin();
-        fs.setLastModTime(path, year, month, date, hour, minute, second);
+        for (uint32_t i = 0; i < TOTAL_FILES; i++) {
+
+            unsigned long timestamp = fileCloseTimestamps[i];
+
+            updateFileTimestamp(i, timestamp);
+        }
+
+        timestampsWritten = true;
+
         fs.end();
-        updatemodifiedtime = true;
-    } else if (state == 1 && updatemodifiedtime == true) {
-        updatemodifiedtime = false;
     }
-    delay(100);
+
+    delay(20);
 }
 
 void printInfo(void)
@@ -110,4 +138,98 @@ void printInfo(void)
     Camera.printInfo();
     Serial.println("- MP4 Recording Information -");
     mp4.printInfo();
+}
+
+int MP4FileClosed(void *parm)
+{
+    uint32_t index = fileCloseCount;
+
+    if (index < TOTAL_FILES) {
+
+        // Capture NTP-synchronized clock at actual MP4 stop event
+        fileCloseTimestamps[index] = timeClient.getEpochTime();
+
+        fileCloseCount = index + 1;
+    }
+
+    return 0;
+}
+
+void updateFileTimestamp(uint32_t index, unsigned long epoch)
+{
+    time_t fileTime = (time_t)epoch;
+    struct tm *timeinfo = gmtime(&fileTime);
+
+    if (timeinfo == NULL) {
+        Serial.println("ERROR: Time conversion failed");
+        return;
+    }
+
+    uint16_t year = timeinfo->tm_year + 1900;
+    uint16_t month = timeinfo->tm_mon + 1;
+    uint16_t day = timeinfo->tm_mday;
+    uint16_t hour = timeinfo->tm_hour;
+    uint16_t minute = timeinfo->tm_min;
+    uint16_t second = timeinfo->tm_sec;
+
+    String baseFileName = mp4.getRecordingFileName();
+    uint32_t fileCount = mp4.getRecordingFileCount();
+
+    if (fileCount == 1) {
+        snprintf(
+            path,
+            sizeof(path),
+            "%s%s.mp4",
+            fs.getRootPath(),
+            baseFileName.c_str()
+        );
+    } else {
+        snprintf(
+            path,
+            sizeof(path),
+            "%s%s_%lu.mp4",
+            fs.getRootPath(),
+            baseFileName.c_str(),
+            (unsigned long)index
+        );
+    }
+
+    Serial.print("Updating: ");
+    Serial.println(path);
+
+    char timeBuffer[64];
+
+    snprintf(
+        timeBuffer,
+        sizeof(timeBuffer),
+        "Close time: %04u-%02u-%02u %02u:%02u:%02u",
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second);
+
+    Serial.println(timeBuffer);
+
+    if (!fs.exists(path)) {
+        Serial.println("ERROR: File not found");
+        return;
+    }
+
+    int ret = fs.setLastModTime(
+        path,
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second);
+
+    if (ret == 0) {
+        Serial.println("Timestamp updated successfully");
+    } else {
+        Serial.print("setLastModTime failed: ");
+        Serial.println(ret);
+    }
 }

--- a/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/VideoOnlyWithNTPClient/VideoOnlyWithNTPClient.ino
+++ b/Arduino_package/hardware/libraries/Multimedia/examples/RecordMP4/VideoOnlyWithNTPClient/VideoOnlyWithNTPClient.ino
@@ -140,7 +140,7 @@ void printInfo(void)
     mp4.printInfo();
 }
 
-int MP4FileClosed(void *parm)
+int MP4FileClosed(void *param)
 {
     uint32_t index = fileCloseCount;
 

--- a/Arduino_package/hardware/libraries/Multimedia/src/MP4Recording.cpp
+++ b/Arduino_package/hardware/libraries/Multimedia/src/MP4Recording.cpp
@@ -2,6 +2,12 @@
 
 #include "MP4Recording.h"
 #include "mp4_drv.h"
+#include "module_mp4.h"
+
+void MP4Recording::setRecordingStopCallback(int (*callback)(void*))
+{
+    stopCallback = callback;
+}
 
 MP4Recording::MP4Recording(void)
 {
@@ -89,6 +95,11 @@ void MP4Recording::begin(void)
     }
     mp4SetParams(_p_mmf_context->priv, &mp4Params);
     mp4SetLoopMode(_p_mmf_context->priv, loopEnable);
+
+    if (stopCallback != NULL) {
+        mp4_control(_p_mmf_context->priv, CMD_MP4_SET_STOP_CB, (int)(uintptr_t)stopCallback);
+    }
+
     mp4RecordingStart(_p_mmf_context->priv, &mp4Params);
 }
 

--- a/Arduino_package/hardware/libraries/Multimedia/src/MP4Recording.h
+++ b/Arduino_package/hardware/libraries/Multimedia/src/MP4Recording.h
@@ -26,7 +26,7 @@ public:
     void setRecordingFileCount(uint32_t count);
     void setLoopRecording(int enable);
     void setRecordingDataType(uint8_t type);
-	void setRecordingStopCallback(int (*callback)(void*));
+    void setRecordingStopCallback(int (*callback)(void*));
     String getRecordingFileName(void);
     uint32_t getRecordingDuration(void);
     uint32_t getRecordingFileCount(void);
@@ -37,7 +37,7 @@ public:
 private:
     int loopEnable = 0;
     mp4_params_t mp4Params;
-	int (*stopCallback)(void*) = NULL;
+    int (*stopCallback)(void*) = NULL;
 };
 
 #endif

--- a/Arduino_package/hardware/libraries/Multimedia/src/MP4Recording.h
+++ b/Arduino_package/hardware/libraries/Multimedia/src/MP4Recording.h
@@ -26,7 +26,7 @@ public:
     void setRecordingFileCount(uint32_t count);
     void setLoopRecording(int enable);
     void setRecordingDataType(uint8_t type);
-
+	void setRecordingStopCallback(int (*callback)(void*));
     String getRecordingFileName(void);
     uint32_t getRecordingDuration(void);
     uint32_t getRecordingFileCount(void);
@@ -37,6 +37,7 @@ public:
 private:
     int loopEnable = 0;
     mp4_params_t mp4Params;
+	int (*stopCallback)(void*) = NULL;
 };
 
 #endif


### PR DESCRIPTION
## Description of Change
- Modify RecordMP4 with NTP Client Examples
- Resolve NTP-based timestamp updates for recordings with different filenames and multiple recorded files

## Tests and Environments 
- AMB82-mini
- ambpro2_arduino V4.1.1
- Arduino IDE 2.3.6
- Windows 11
